### PR TITLE
Add Argo Rollouts canary release to checkoutservice

### DIFF
--- a/checkoutservice/checkoutservice.yaml
+++ b/checkoutservice/checkoutservice.yaml
@@ -1,8 +1,9 @@
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
 metadata:
   name: checkoutservice
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: checkoutservice
@@ -53,6 +54,17 @@ spec:
             limits:
               cpu: 200m
               memory: 128Mi
+  strategy:
+    canary:
+      steps:
+        - setWeight: 20
+        - pause: {duration: 300}
+        - setWeight: 50
+        - pause: {duration: 300}
+        - setWeight: 100
+        - pause: {duration: 60}
+      maxSurge: 1
+      maxUnavailable: 0
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR adds an Argo Rollouts canary release manifest to checkoutservice. Generated by Aiden.